### PR TITLE
Added Semigroup instance for Mask. Retained backwards compatibility.

### DIFF
--- a/linux-inotify.cabal
+++ b/linux-inotify.cabal
@@ -51,6 +51,9 @@ library
                        hashable >= 1.1.2,
                        unix
 
+  if !impl(ghc >= 8.0)
+     build-depends: semigroups == 0.18.*
+
   ghc-options: -Wall
 
 source-repository head


### PR DESCRIPTION
Updating linux-inotify for the Semigroup Monoid proposal. I followed the standards as outlined by https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid

Let me know if changes are required. Thanks!